### PR TITLE
初始化时直接传入installtionId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore idea stuff
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore idea stuff
 .idea/*
+# Ignore key.js
+key.js

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,6 +11,8 @@
 </head>
 <body>
     <h1>wangxiao</h1>
+    <!--推送的key文件，需要自己新建.-->
+<script src="key.js"></script>
 <script src="../src/lc.push.js"></script>
 <script src="test.js"></script>
 </body>

--- a/demo/test.js
+++ b/demo/test.js
@@ -1,16 +1,28 @@
-// 请换成自己的 appId 和 appKey
-var appId = '9p6hyhh60av3ukkni3i9z53q1l8yy3cijj6sie3cewft18vm';
-var appKey = 'nhqqc1x7r7r89kp8pggrme57i374h3vyd0ukr2z3ayojpvf4';
+// 请换成自己的 appId 和 appKey 或者在同一文件夹下新建key.js声明全局变量appId和appKey
+if(typeof appId === 'undefined'){
+    var appId = '9p6hyhh60av3ukkni3i9z53q1l8yy3cijj6sie3cewft18vm';
+    var appKey = 'nhqqc1x7r7r89kp8pggrme57i374h3vyd0ukr2z3ayojpvf4';
+}
+
 var push;
 
 // 每次调用生成一个聊天实例
 createNew();
 
 function createNew() {
+    // 自动注册installation(注册成安卓23333)
     push = lc.push({
         appId: appId,
         appKey: appKey
     });
+
+    // 使用之前注册过的installationId
+    //push = lc.push({
+    //    appId: appId,
+    //    appKey: appKey,
+    //    // 替换成从控制台->存储->installation 看到的installationId. 随便找一行.
+    //    installationId:'bcb544de-a45c-4e1f-a47b-7c835ef84d70'
+    //});
 
     // 可以链式调用
     push.open(function() {

--- a/src/lc.push.js
+++ b/src/lc.push.js
@@ -349,7 +349,12 @@ void function(win) {
         else {
             options.channels = options.channels || [];
             var pushObject = newPushObject();
-            options.id = engine.getId(options);
+            // 支持创建时传入installationId,这样可以跟已有的用户系统关联.
+            if(typeof options.installationId !== 'undefined'){
+                options.id =  options.installationId;
+            }else{
+                options.id = engine.getId(options);
+            }
             pushObject.cache.options = options;
             pushObject.cache.ec = tool.eventCenter();
             return pushObject;


### PR DESCRIPTION
现在的sdk是从localstorgage中获取installationId，没有的话就自动生成一个然后伪装成安卓去注册然后login.
这样的话不太方便集成到现用的用户系统中来实现web端的推送. 但是直接传入installationId的话就会好很多.

eg: 小明是网站a的用户，网站在登陆(注册)时通过调用api注册一个installation给他,存到自己的数据库里，然后每次登陆之后把他的installationId直接输出到前端，然后sdk可以直接login. 甚至可以用某个安卓设备的installationId来接收该设备收到的信息. 

BTW: 长时间不用的installation会收不到推送？以前好像在文档里看到过. thx
